### PR TITLE
Use NEXTPNR_NAMESPACE macro's now that headers are seperated.

### DIFF
--- a/fpga_interchange/bits.cc
+++ b/fpga_interchange/bits.cc
@@ -20,9 +20,9 @@
 #include "gtest/gtest.h"
 
 #include "bits.h"
-#include "nextpnr.h"
+#include "nextpnr_namespaces.h"
 
-namespace nextpnr {
+NEXTPNR_NAMESPACE_BEGIN
 
 class BitsTest : public ::testing::Test
 {
@@ -55,4 +55,4 @@ TEST_F(BitsTest, ctz)
     }
 }
 
-}; // namespace nextpnr
+NEXTPNR_NAMESPACE_END

--- a/fpga_interchange/dynamic_bitarray.cc
+++ b/fpga_interchange/dynamic_bitarray.cc
@@ -19,10 +19,11 @@
 
 #include "gtest/gtest.h"
 
-#include "dynamic_bitarray.h"
 #include <climits>
+#include "dynamic_bitarray.h"
+#include "nextpnr_namespaces.h"
 
-namespace nextpnr {
+NEXTPNR_NAMESPACE_BEGIN
 
 class DynamicBitarrayTest : public ::testing::Test
 {
@@ -32,7 +33,7 @@ TEST_F(DynamicBitarrayTest, oneshot)
 {
     for (size_t i = 0; i < 100; ++i) {
         std::vector<uint8_t> simple_storage;
-        nextpnr::DynamicBitarray<> bitarray;
+        DynamicBitarray<> bitarray;
         ASSERT_EQ(bitarray.bits_per_value(), size_t(CHAR_BIT));
 
         simple_storage.resize(i);
@@ -57,7 +58,7 @@ TEST_F(DynamicBitarrayTest, oneshot)
 TEST_F(DynamicBitarrayTest, resize)
 {
     std::vector<uint8_t> simple_storage;
-    nextpnr::DynamicBitarray<> bitarray;
+    DynamicBitarray<> bitarray;
 
     for (size_t i = 0; i < 100; ++i) {
 
@@ -80,7 +81,7 @@ TEST_F(DynamicBitarrayTest, resize)
 
 TEST_F(DynamicBitarrayTest, fill)
 {
-    nextpnr::DynamicBitarray<> bitarray;
+    DynamicBitarray<> bitarray;
 
     for (size_t i = 0; i < 100; ++i) {
         bitarray.resize(i);
@@ -97,4 +98,4 @@ TEST_F(DynamicBitarrayTest, fill)
     }
 }
 
-}; // namespace nextpnr
+NEXTPNR_NAMESPACE_END


### PR DESCRIPTION
Required for https://github.com/YosysHQ/nextpnr/pull/625